### PR TITLE
Update to omniauth-oauth2 >= 1.5

### DIFF
--- a/omniauth-office365.gemspec
+++ b/omniauth-office365.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::Office365::VERSION
 
   # Lock at 1.3.x due to https://github.com/intridea/omniauth-oauth2/issues/81
-  gem.add_dependency 'omniauth-oauth2', '~> 1.3.1'
+  gem.add_dependency 'omniauth-oauth2', '>= 1.5'
 
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
This is necessary to be in line with the other omniauth strategies we
use and to avoid bundling issues